### PR TITLE
fixing the age calculation and return early, if condition is not satisfied

### DIFF
--- a/aged-content-message.php
+++ b/aged-content-message.php
@@ -79,6 +79,11 @@ function aged_content_message__the_content( $content ) {
 	$years_diff = ( time() - get_the_time( 'U' ) ) / ( 60 * 60 * 24 * 365);
 	$age = apply_filters( 'aged_content_message__the_content_age', floor( $years_diff ) );
 
+	// Return original content if not too old
+	if ( $years_diff < apply_filters( 'aged_content_message__the_content_min_age', 1 ) ) {
+		return $content;
+	}
+
 	// Singular/plural form message.
 	$msg = apply_filters(
 		'aged_content_message__the_content_message',
@@ -95,9 +100,5 @@ function aged_content_message__the_content( $content ) {
 		)
 	);
 
-	if ( $years_diff >= apply_filters( 'aged_content_message__the_content_min_age', 1 ) ) {
-		$content = $msg . $content;
-	}
-
-	return $content;
+	return $msg . $content;
 }


### PR DESCRIPTION
There have been two issues:
1. The variable `$msg` was build, using format string function and translations, even though the post was not aged  and the `$content` variable was not changed.
2. The age calculation was wrong. It only used the year value for it's calculation, rather than the full date. So a post from 2013-12-31 would have been shown as aged after only a day (2014-01-01) using only the year value for the calculation. The new version uses the current timestamp and the post timestamp to calculate the difference as a floating point number. It than uses the rounded down vaule of the fraction.
