### PR TITLE
New feature: use modified post time instead of post time

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -113,6 +113,14 @@ function aged_content_message__settings_init() {
 	);
 
 	add_settings_field(
+		'modified_time',
+		__( 'Use last modified time instead of post time', 'aged-content-message' ),
+		'aged_content_message__modified_time',
+		'aged_content_message',
+		'aged_content_message_settings'
+	);
+
+	add_settings_field(
 		'heading',
 		__( 'Message Heading', 'aged-content-message' ),
 		'aged_content_message__heading_render',
@@ -178,6 +186,28 @@ function aged_content_message__activate_render() {
 	?>
 	<label for="aged_content_message__settings[activate]">
 		<input type="checkbox" id="aged_content_message__settings[activate]" name="aged_content_message__settings[activate]" <?php checked( esc_attr( $value ), 1 ); ?> value="1">
+		<?php echo $description; ?>
+	</label>
+	<?php
+}
+
+/**
+ * Modified time setting.
+ *
+ * @return void
+ */
+function aged_content_message__modified_time() {
+
+	$options = get_option( 'aged_content_message__settings' );
+	$value   = isset( $options[ 'modified_time' ] ) ? absint( $options[ 'modified_time' ] ) : 0;
+	$description = __( 'Use last modified time instead of post time.', 'aged-content-message' );
+
+	if ( ! empty( $value ) ) {
+		$description = __( '<strong>Your using last modified time on your website right now.</strong> Uncheck to use post time instead.', 'aged-content-message' );
+	}
+	?>
+	<label for="aged_content_message__settings[modified_time]">
+		<input type="checkbox" id="aged_content_message__settings[modified_time]" name="aged_content_message__settings[modified_time]" <?php checked( esc_attr( $value ), 1 ); ?> value="1">
 		<?php echo $description; ?>
 	</label>
 	<?php

--- a/inc/frontend.php
+++ b/inc/frontend.php
@@ -22,8 +22,12 @@ function aged_content_message__the_content( $content ) {
 		return $content;
 	}
 
+	$options = get_option( 'aged_content_message__settings' );
+
+	$post_time = ( isset( $options[ 'modified_time' ] ) && '1' === $options[ 'modified_time' ] ) ? get_the_modified_time( 'U' ) : get_the_time( 'U' );
+
 	// Calculate age in years as a float
-	$years_diff = ( time() - get_the_time( 'U' ) ) / YEAR_IN_SECONDS;
+	$years_diff = ( time() - $post_time ) / YEAR_IN_SECONDS;
 	$age        = apply_filters( 'aged_content_message__the_content_age', floor( $years_diff ) );
 
 	$options = get_option( 'aged_content_message__settings' );


### PR DESCRIPTION
@Zodiac1978 Test: Pull branch “feature/modified_time”; activate setting “Use last modified time
instead of post time”; only posts with modified time longer than n
[Minimal Post Age] ago should display the message now. Confirm?