### PR TITLE
Improve `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.bak
 *.psd
 *.ai
+
+# Files and folders related to build/test tools
+/vendor
+/composer.lock


### PR DESCRIPTION
Add `/vendor` and `/composer.lock` to .gitignore, because they are only needed for development.